### PR TITLE
filter data with timeline brushing

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -45,10 +45,13 @@ d3.csv('data/occurrences.csv')
       'containerWidth': 1500
     }, timeData);
 
-
     timeline.brush.on("end", function ({ selection }) {
-          if (selection) console.log(timeline.brushed(selection));
+          if (selection) { 
+            brushedYrs = timeline.brushed(selection);
+            filteredData = data.filter(function(d) {return(d.year >= brushedYrs[0] && d.year <= brushedYrs[1])});
+          }
         });
+
 
   })
   .catch(error => console.error(error));
@@ -60,7 +63,7 @@ function updateColor(scale)
 }
 
 function getTimelineData(data) {
-    let timeData = new Array(159);
+  let timeData = new Array(159);
     for (let i=0; i < timeData.length; i++){
       timeData[i] = {"year": 1859 + i, "count": 0};
     }
@@ -73,5 +76,5 @@ function getTimelineData(data) {
 }
 
 function resetTimeline(){
-    timeline.updateVis();
+  timeline.updateVis();
 }


### PR DESCRIPTION
the filtered data is saved as "filteredData". Ideally, I think we could just call the update functions with the new data array.

Also I used the "getTimelineData" function instead of grouping or mapping since those omitted years with 0 samples (which I think we still want to display in a timeline), so when the map is brushed, we would need to call that function and then the update function for the timeline with the filtered data